### PR TITLE
Sort homepage list by creation time

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -55,6 +55,8 @@ const mockQuestions: Question[] = [
   },
 ]
 
+const sortByDateDesc = (a: Question, b: Question) => new Date(b.submittedAt).getTime() - new Date(a.submittedAt).getTime()
+
 export default function HomePage() {
   const [searchQuery, setSearchQuery] = useState("")
   const [brandFilter, setBrandFilter] = useState("")
@@ -67,7 +69,7 @@ export default function HomePage() {
   useEffect(() => {
     const stored: Question[] =
       typeof window !== "undefined" ? (JSON.parse(localStorage.getItem("questions") || "[]") as Question[]) : []
-    const combined = [...mockQuestions, ...stored]
+    const combined = [...mockQuestions, ...stored].sort(sortByDateDesc)
     setQuestions(combined)
     setFilteredQuestions(combined)
   }, [])
@@ -119,7 +121,7 @@ export default function HomePage() {
       filtered = filtered.filter((q: Question) => q.status === status)
     }
 
-    setFilteredQuestions(filtered)
+    setFilteredQuestions(filtered.sort(sortByDateDesc))
   }
 
   const getStatusColor = (status: string) => {


### PR DESCRIPTION
The homepage question list is now sorted by creation time, with the newest questions appearing first.

*   A new helper function, `sortByDateDesc`, was introduced in `app/page.tsx`. This function compares `submittedAt` timestamps to sort `Question` objects in descending order.
*   The initial loading of questions within the `useEffect` hook in `app/page.tsx` was updated to apply `sortByDateDesc` to the combined `mockQuestions` and `localStorage` stored questions.
*   The `applyFilters` function in `app/page.tsx` was modified to ensure that filtered results are also sorted by `sortByDateDesc` before being displayed.

These changes ensure that the list consistently presents the most recent questions at the top, regardless of initial load or subsequent filtering actions.